### PR TITLE
Indexing updates can be optimized

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ By default, there aren't any special settings, apart for String fields, where th
 *Optional:* set to True to make efficient queries when automatically mapping to database objects. This will *always* restrict fetching to the fields set in `fields` and in `additional_fields`.
 *Note:* You can also perform an optimal database query with `.only('__model')`, which will use the same fields as `optimize_queries`, or `.only('__fields')`, which will use the fields provided in the `.fields()` call.
 
+##### indexing_query
+*Optional:* set to a QuerySet instance to specify the query used when the search_index command is ran to index. This **does not** affect how each piece of content is indexed.
 
 #### Example
 ```python
@@ -169,6 +171,8 @@ class ArticleIndex(ModelIndex):
                     'title': {'boost': 1.75},
                     'description': {'boost': 1.35},
                     'full_text': {'boost': 1.125}}
+        optimized_queries = True
+        indexing_query = Article.objects.defer(*exclude).select_related().all().prefetch_related('tags')
 
 ```
 ## SearchAlias

--- a/bungiesearch/management/commands/search_index.py
+++ b/bungiesearch/management/commands/search_index.py
@@ -159,7 +159,7 @@ class Command(BaseCommand):
                 model_names = [model for index in src.get_indices() for model in src.get_models(index)]
             # Update index.
             for model_name in model_names:
-                if hasattr(src.get_model_index(model_name), 'optimize_queries'):
-                    update_index(src.get_model_index(model_name).optimize_queries, model_name, bulk_size=options['bulk_size'], num_docs=options['num_docs'], start_date=options['start_date'], end_date=options['end_date'])
+                if hasattr(src.get_model_index(model_name), 'indexing_query'):
+                    update_index(src.get_model_index(model_name).indexing_query, model_name, bulk_size=options['bulk_size'], num_docs=options['num_docs'], start_date=options['start_date'], end_date=options['end_date'])
                 else:
                     update_index(src.get_model_index(model_name).get_model().objects.all(), model_name, bulk_size=options['bulk_size'], num_docs=options['num_docs'], start_date=options['start_date'], end_date=options['end_date'])

--- a/bungiesearch/management/commands/search_index.py
+++ b/bungiesearch/management/commands/search_index.py
@@ -159,4 +159,7 @@ class Command(BaseCommand):
                 model_names = [model for index in src.get_indices() for model in src.get_models(index)]
             # Update index.
             for model_name in model_names:
-                update_index(src.get_model_index(model_name).get_model().objects.all(), model_name, bulk_size=options['bulk_size'], num_docs=options['num_docs'], start_date=options['start_date'], end_date=options['end_date'])
+                if hasattr(src.get_model_index(model_name), 'optimize_queries'):
+                    update_index(src.get_model_index(model_name).optimize_queries, model_name, bulk_size=options['bulk_size'], num_docs=options['num_docs'], start_date=options['start_date'], end_date=options['end_date'])
+                else:
+                    update_index(src.get_model_index(model_name).get_model().objects.all(), model_name, bulk_size=options['bulk_size'], num_docs=options['num_docs'], start_date=options['start_date'], end_date=options['end_date'])

--- a/tests/core/search_indices.py
+++ b/tests/core/search_indices.py
@@ -22,3 +22,4 @@ class NoUpdatedFieldIndex(ModelIndex):
         model = NoUpdatedField
         exclude = ('description', )
         optimize_queries = True
+        indexing_query = NoUpdatedField.objects.defer(*exclude).select_related().all()


### PR DESCRIPTION
ModelIndex Meta can now have an `indexing_query` which will be used only for indexing. More information in `README.md`.