### PR TITLE
Version 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,21 @@ This can also be used to index foreign keys:
 some_field_name = StringField(eval_as='",".join([item for item in obj.some_foreign_relation.values_list("some_field", flat=True)]) if obj.some_foreign_relation else ""')
 ```
 
+### Class methods
+##### matches_indexing_condition
+Override this function to specify whether an item should be indexed or not. This is useful when defining multiple indices (and ModelIndex classes) for a given model.
+This method's signature and super class code is as follows, and allows indexing of all items.
+```python
+def matches_indexing_condition(self, item):
+    return True
+```
+
+For example, if a given elasticsearch index should contain only item whose title starts with `"Awesome"`, then this method can be overridden as follows.
+```python
+def matches_indexing_condition(self, item):
+    return item.title.startswith("Awesome")
+```
+
 ### Meta subclass attributes
 **Note**: in the following, any variable defined a being a `list` could also be a `tuple`.
 ##### model
@@ -160,12 +175,16 @@ Enables support for a given model to be indexed on several elasticsearch indices
 **Note**: if all managed models are set with `default=False` then Bungiesearch will fail to find and index that model.
 
 #### Example
+Indexes all objects of `Article`, as long as their `updated` datetime is less than [21 October 2015 04:29](https://en.wikipedia.org/wiki/Back_to_the_Future_Part_II).
 ```python
 from core.models import Article
 from bungiesearch.indices import ModelIndex
-
+from datetime import datetime
 
 class ArticleIndex(ModelIndex):
+
+    def matches_indexing_condition(self, item):
+        return item.updated < datetime.datetime(2015, 9, 21, 4, 29)
 
     class Meta:
         model = Article

--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ By default, there aren't any special settings, apart for String fields, where th
 ##### indexing_query
 *Optional:* set to a QuerySet instance to specify the query used when the search_index command is ran to index. This **does not** affect how each piece of content is indexed.
 
+##### default
+Enables support for a given model to be indexed on several elasticsearch indices. Set to `False` on all but the default index.
+**Note**: if all managed models are set with `default=False` then Bungiesearch will fail to find and index that model.
+
 #### Example
 ```python
 from core.models import Article

--- a/bungiesearch/__init__.py
+++ b/bungiesearch/__init__.py
@@ -60,14 +60,6 @@ class Bungiesearch(Search):
                 cls._model_to_index[model].append(index_name)
                 cls._model_name_to_index[model.__name__].append(index_name)
 
-        print '_index_to_model             ', cls._index_to_model
-        print '_model_name_to_index        ', cls._model_name_to_index
-        print '_model_name_to_model_idx    ', cls._model_name_to_model_idx
-        print '_model_to_index             ', cls._model_to_index
-        print '_model_name_to_default_index', cls._model_name_to_default_index
-        print '_idx_name_to_mdl_to_mdlidx', cls._idx_name_to_mdl_to_mdlidx
-
-        import pdb;pdb.set_trace()
         # Loading aliases.
         for alias_prefix, module_str in cls.BUNGIE.get('ALIASES', {}).iteritems():
             if alias_prefix is None:

--- a/bungiesearch/__init__.py
+++ b/bungiesearch/__init__.py
@@ -24,8 +24,8 @@ class Bungiesearch(Search):
 
     _cached_es_instances = {}
     # Let's go through the settings in order to map each defined Model/ModelIndex to the elasticsearch index_name.
-    _index_to_model_idx, _index_to_model = defaultdict(list), defaultdict(list)
-    _model_to_index, _model_name_to_index, _model_name_to_model_idx, = defaultdict(list), defaultdict(list), defaultdict(list)
+    _model_to_index, _model_name_to_index, _model_name_to_model_idx = defaultdict(list), defaultdict(list), defaultdict(list)
+    _index_to_model, _idx_name_to_mdl_to_mdlidx = defaultdict(list), defaultdict(dict)
     _model_name_to_default_index, _alias_hooks = {}, {}
     _managed_models = []
     __loaded_indices__ = False
@@ -44,9 +44,9 @@ class Bungiesearch(Search):
                     if issubclass(index_obj, ModelIndex) and index_obj != ModelIndex:
                         index_instance = index_obj()
                         assoc_model = index_instance.get_model()
-                        cls._index_to_model_idx[index_name].append(index_instance)
                         cls._index_to_model[index_name].append(assoc_model)
                         cls._model_name_to_model_idx[assoc_model.__name__].append(index_instance)
+                        cls._idx_name_to_mdl_to_mdlidx[index_name][assoc_model.__name__] = index_instance
                         if index_instance.is_default:
                             if assoc_model.__name__ in cls._model_name_to_default_index:
                                 raise AttributeError('ModelIndex {} on index {} is marked as default, but {} was already set as default.'.format(index_instance, index_name, cls._model_name_to_default_index[assoc_model.__name__]))
@@ -55,12 +55,19 @@ class Bungiesearch(Search):
                     pass # Oops, just attempted to get subclasses of a non-class.
 
         # Create reverse maps in order to have O(1) access.
-        import pdb;pdb.set_trace()
         for index_name, models in cls._index_to_model.iteritems():
             for model in models:
                 cls._model_to_index[model].append(index_name)
                 cls._model_name_to_index[model.__name__].append(index_name)
 
+        print '_index_to_model             ', cls._index_to_model
+        print '_model_name_to_index        ', cls._model_name_to_index
+        print '_model_name_to_model_idx    ', cls._model_name_to_model_idx
+        print '_model_to_index             ', cls._model_to_index
+        print '_model_name_to_default_index', cls._model_name_to_default_index
+        print '_idx_name_to_mdl_to_mdlidx', cls._idx_name_to_mdl_to_mdlidx
+
+        import pdb;pdb.set_trace()
         # Loading aliases.
         for alias_prefix, module_str in cls.BUNGIE.get('ALIASES', {}).iteritems():
             if alias_prefix is None:
@@ -109,13 +116,15 @@ class Bungiesearch(Search):
             raise KeyError('Could not find any index defined for model {}. Is the model in one of the model index modules of BUNGIESEARCH["INDICES"]?'.format(model))
 
     @classmethod
-    def get_model_index(cls, model):
+    def get_model_index(cls, model, default=True):
         '''
-        Returns the model index for the given model as a string.
-        :param model: model name or model class if via_class set to True.
+        Returns the default model index for the given model, or the list of indices if default is False.
+        :param model: model name as a string.
         :raise KeyError: If the provided model does not have any index associated.
         '''
         try:
+            if default:
+                return cls._model_name_to_default_index[model]
             return cls._model_name_to_model_idx[model]
         except KeyError:
             raise KeyError('Could not find any model index defined for model {}.'.format(model))
@@ -125,7 +134,7 @@ class Bungiesearch(Search):
         '''
         Returns the list of indices defined in the settings.
         '''
-        return cls._index_to_model_idx.keys()
+        return cls._idx_name_to_mdl_to_mdlidx.keys()
 
     @classmethod
     def get_models(cls, index, as_class=False):
@@ -135,7 +144,7 @@ class Bungiesearch(Search):
         :param as_class: set to True to return the model as a model object instead of as a string.
         '''
         try:
-            return cls._index_to_model[index] if as_class else [model.__name__ for model in cls._index_to_model[index]]
+            return cls._index_to_model[index] if as_class else cls._idx_name_to_mdl_to_mdlidx[index].keys()
         except KeyError:
             raise KeyError('Could not find any index named {}. Is this index defined in BUNGIESEARCH["INDICES"]?'.format(index))
 
@@ -146,7 +155,7 @@ class Bungiesearch(Search):
         :param index: index name.
         '''
         try:
-            return cls._index_to_model_idx[index]
+            return cls._idx_name_to_mdl_to_mdlidx[index].values()
         except KeyError:
             raise KeyError('Could not find any index named {}. Is this index defined in BUNGIESEARCH["INDICES"]?'.format(index))
 
@@ -168,16 +177,17 @@ class Bungiesearch(Search):
         found_results = {}
         for pos, result in enumerate(raw_results):
             model_name = result._meta.doc_type
-            if model_name not in Bungiesearch._model_name_to_index or Bungiesearch._model_name_to_index[model_name] != result._meta.index:
-                logging.warn('Returned object of type {} ({}) is not defined in the settings, or is not associated to the same index as in the settings.'.format(model_name, result))
+            if model_name not in Bungiesearch._model_name_to_index or result._meta.index not in Bungiesearch._model_name_to_index[model_name]:
+                logging.warning('Returned object of type {} ({}) is not defined in the settings, or is not associated to the same index as in the settings.'.format(model_name, result))
                 results[pos] = result
             else:
-                model_results[model_name].append(result.id)
+                model_results['{}.{}'.format(result._meta.index, model_name)].append(result.id)
                 found_results['{}.{}'.format(model_name, result.id)] = (pos, result._meta)
         # Now that we have model ids per model name, let's fetch everything at once.
 
-        for model_name, ids in model_results.iteritems():
-            model_idx = Bungiesearch._model_name_to_model_idx[model_name]
+        for ref_name, ids in model_results.iteritems():
+            index_name, model_name = ref_name.split('.')
+            model_idx = Bungiesearch._idx_name_to_mdl_to_mdlidx[index_name][model_name]
             model_obj = model_idx.get_model()
             items = model_obj.objects.filter(pk__in=ids)
             if instance:

--- a/bungiesearch/__init__.py
+++ b/bungiesearch/__init__.py
@@ -174,9 +174,9 @@ class Bungiesearch(Search):
                 results[pos] = result
             else:
                 model_results['{}.{}'.format(result._meta.index, model_name)].append(result.id)
-                found_results['{}.{}'.format(model_name, result.id)] = (pos, result._meta)
-        # Now that we have model ids per model name, let's fetch everything at once.
+                found_results['{1._meta.index}.{0}.{1.id}'.format(model_name, result)] = (pos, result._meta)
 
+        # Now that we have model ids per model name, let's fetch everything at once.
         for ref_name, ids in model_results.iteritems():
             index_name, model_name = ref_name.split('.')
             model_idx = Bungiesearch._idx_name_to_mdl_to_mdlidx[index_name][model_name]
@@ -194,7 +194,7 @@ class Bungiesearch(Search):
                     items = items.only(*[field for field in model_obj._meta.get_all_field_names() if field in desired_fields])
             # Let's reposition each item in the results and set the _bungiesearch meta information.
             for item in items:
-                pos, meta = found_results['{}.{}'.format(model_name, item.pk)]
+                pos, meta = found_results['{}.{}.{}'.format(index_name, model_name, item.pk)]
                 item._searchmeta = meta
                 results[pos] = item
 

--- a/bungiesearch/aliases.py
+++ b/bungiesearch/aliases.py
@@ -1,3 +1,4 @@
+import logging
 
 class SearchAlias(object):
     '''
@@ -40,5 +41,9 @@ class SearchAlias(object):
         if self.model:
             return self.model
         if self.search_instance._doc_type and len(self.search_instance._doc_type) == 1:
-            return self.search_instance._model_name_to_model_idx[self.search_instance._doc_type[0]].get_model()
+            idxes = self.search_instance._model_name_to_model_idx[self.search_instance._doc_type[0]]
+            first_mdl = idxes[0].get_model()
+            if all(mdlidx.get_model() == first_mdl for mdlidx in idxes[1:]): 
+                return first_mdl
+            raise ValueError('SearchAlias {} is associated to more than one index, and the model is differs between indices!')
         raise ValueError('Instance associated to zero doc types or more than one.')

--- a/bungiesearch/aliases.py
+++ b/bungiesearch/aliases.py
@@ -1,5 +1,3 @@
-import logging
-
 class SearchAlias(object):
     '''
     Defines search aliases for specific models. Essentially works like Django Managers but for Bungiesearch.

--- a/bungiesearch/indices.py
+++ b/bungiesearch/indices.py
@@ -36,6 +36,7 @@ class ModelIndex(object):
         id_field = getattr(_meta, 'id_field', 'id')
         self.updated_field = getattr(_meta, 'updated_field', None)
         self.optimize_queries = getattr(_meta, 'optimize_queries', False)
+        self.is_default = getattr(_meta, 'default', True)
 
         # Add in fields from the model.
         self.fields.update(self._get_fields(fields, excludes, hotfixes))
@@ -115,3 +116,6 @@ class ModelIndex(object):
             final_fields[f.name] = django_field_to_index(f, **attr)
 
         return final_fields
+
+    def __str__(self, *args, **kwargs):
+        return '<{0.__class__.__name__}:{0.model.__name__}>'.format(self)

--- a/bungiesearch/indices.py
+++ b/bungiesearch/indices.py
@@ -54,6 +54,12 @@ class ModelIndex(object):
                 logging.info('Overwriting implicitly defined model field {} ({}) its explicit definition: {}.'.format(cls_attr, unicode(self.fields[cls_attr]), unicode(obj)))
             self.fields[cls_attr] = obj
 
+    def matches_indexing_condition(self, item):
+        '''
+        Returns True by default to index all documents.
+        '''
+        return True
+
     def get_model(self):
         return self.model
 
@@ -117,5 +123,5 @@ class ModelIndex(object):
 
         return final_fields
 
-    def __str__(self, *args, **kwargs):
+    def __str__(self):
         return '<{0.__class__.__name__}:{0.model.__name__}>'.format(self)

--- a/bungiesearch/management/commands/search_index.py
+++ b/bungiesearch/management/commands/search_index.py
@@ -100,7 +100,7 @@ class Command(BaseCommand):
                     indices = src.get_indices()
 
                 for index in indices:
-                    logging.warn('Deleting elastic search index {}.'.format(index))
+                    logging.warning('Deleting elastic search index {}.'.format(index))
                     es.indices.delete(index=index, ignore=404)
 
             else:
@@ -108,7 +108,8 @@ class Command(BaseCommand):
                 if options['models']:
                     logging.info('Deleting mapping for models {} on index {}.'.format(options['models'], index))
                     for model_name in options['models'].split():
-                        index_to_doctypes[src.get_index(model_name)].append(model_name)
+                        for index in src.get_index(model_name):
+                            index_to_doctypes[index].append(model_name)
                 elif options['index']:
                     index = options['index']
                     logging.info('Deleting mapping for all models on index {}.'.format(index))
@@ -138,14 +139,14 @@ class Command(BaseCommand):
             if options['models']:
                 model = options['models']
                 for model_name in options['models'].split():
-                    index = src.get_index(model_name)
-                    logging.info('Updating mapping of model/doctype {} on index {}.'.format(model_name, index))
-                    es.indices.put_mapping(model_name, src.get_model_index(model_name).get_mapping(), index=index)
+                    for index in src.get_index(model_name):
+                        logging.info('Updating mapping of model/doctype {} on index {}.'.format(model_name, index))
+                        es.indices.put_mapping(model_name, src.get_model_index(model_name).get_mapping(), index=index)
             else:
                 for model_name, model_idx in src._model_name_to_model_idx.iteritems():
-                    index = src.get_index(model_name)
-                    logging.info('Updating mapping of model/doctype {} on index {}.'.format(model_name, index))
-                    es.indices.put_mapping(model_name, model_idx.get_mapping(), index=index)
+                    for index in src.get_index(model_name):
+                        logging.info('Updating mapping of model/doctype {} on index {}.'.format(model_name, index))
+                        es.indices.put_mapping(model_name, model_idx.get_mapping(), index=index)
 
         else:
             if options['models']:

--- a/bungiesearch/managers.py
+++ b/bungiesearch/managers.py
@@ -8,7 +8,7 @@ class BungiesearchManager(Manager):
     @property
     def search(self):
         from bungiesearch import Bungiesearch
-        return Bungiesearch().index(Bungiesearch.get_index(self.model, via_class=True)).doc_type(self.model.__name__)
+        return Bungiesearch().index(*Bungiesearch.get_index(self.model, via_class=True)).doc_type(self.model.__name__)
 
     def custom_search(self, index, doc_type):
         '''

--- a/bungiesearch/managers.py
+++ b/bungiesearch/managers.py
@@ -1,5 +1,5 @@
 from django.db.models import Manager, signals
-
+import logging
 
 class BungiesearchManager(Manager):
     '''
@@ -9,6 +9,12 @@ class BungiesearchManager(Manager):
     def search(self):
         from bungiesearch import Bungiesearch
         return Bungiesearch().index(*Bungiesearch.get_index(self.model, via_class=True)).doc_type(self.model.__name__)
+
+    def search_index(self, index):
+        from bungiesearch import Bungiesearch
+        if index not in Bungiesearch.get_index(self.model, via_class=True):
+            logging.warning('Model/doctype {} is not present on index {}: search may return no results.'.format(self.model.__name__, index))
+        return Bungiesearch().index(index).doc_type(self.model.__name__)
 
     def custom_search(self, index, doc_type):
         '''

--- a/bungiesearch/utils.py
+++ b/bungiesearch/utils.py
@@ -4,6 +4,7 @@ from . import Bungiesearch
 from elasticsearch.helpers import bulk_index
 from dateutil.parser import parse as parsedt
 from django.utils import timezone
+from elasticsearch.exceptions import RequestError
 
 def update_index(model_items, model_name, bulk_size=100, num_docs=-1, start_date=None, end_date=None):
     '''
@@ -20,35 +21,35 @@ def update_index(model_items, model_name, bulk_size=100, num_docs=-1, start_date
     src = Bungiesearch()
 
     logging.info('Getting index for model {}.'.format(model_name))
-    index_name = src.get_index(model_name)
-    index_instance = src.get_model_index(model_name)
-    model = index_instance.get_model()
-
-    if num_docs == -1:
-        if isinstance(model_items, (list, tuple)):
-            num_docs = len(model_items)
+    for index_name in src.get_index(model_name):
+        index_instance = src.get_model_index(model_name)
+        model = index_instance.get_model()
+    
+        if num_docs == -1:
+            if isinstance(model_items, (list, tuple)):
+                num_docs = len(model_items)
+            else:
+                # Let's parse the start date and end date.
+                if start_date or end_date:
+                    if index_instance.updated_field is None:
+                        raise ValueError('Cannot filter by date on model {}: no updated_field defined in {}\'s Meta class.'.format(model_name, index_instance.__class__.__name__))
+                    if start_date: 
+                        model_items = model_items.filter(**{'{}__gte'.format(index_instance.updated_field): __str_to_tzdate__(start_date)})
+                    if end_date:
+                        model_items = model_items.filter(**{'{}__lte'.format(index_instance.updated_field): __str_to_tzdate__(end_date)})
+                
+                logging.info('Fetching number of documents to be added to {}.'.format(model.__name__))
+                num_docs = model_items.count()
         else:
-            # Let's parse the start date and end date.
-            if start_date or end_date:
-                if index_instance.updated_field is None:
-                    raise ValueError('Cannot filter by date on model {}: no updated_field defined in {}\'s Meta class.'.format(model_name, index_instance.__class__.__name__))
-                if start_date: 
-                    model_items = model_items.filter(**{'{}__gte'.format(index_instance.updated_field): __str_to_tzdate__(start_date)})
-                if end_date:
-                    model_items = model_items.filter(**{'{}__lte'.format(index_instance.updated_field): __str_to_tzdate__(end_date)})
-            
-            logging.info('Fetching number of documents to be added to {}.'.format(model.__name__))
-            num_docs = model_items.count()
-    else:
-        logging.warning('Limiting the number of model_items to be indexed to {}.'.format(num_docs))
-
-    logging.info('Indexing {} documents.'.format(num_docs))
-    prev_step = 0
-    max_docs = num_docs + bulk_size if num_docs > bulk_size else bulk_size + 1
-    for next_step in xrange(bulk_size, max_docs, bulk_size):
-        logging.info('Indexing documents {} to {} of {} total.'.format(prev_step, next_step, num_docs))
-        bulk_index(src.get_es_instance(), [index_instance.serialize_object(doc) for doc in model_items[prev_step:next_step]], index=index_name, doc_type=model.__name__, raise_on_error=True)
-        prev_step = next_step
+            logging.warning('Limiting the number of model_items to be indexed to {}.'.format(num_docs))
+    
+        logging.info('Indexing {} documents on index {}.'.format(num_docs, index_name))
+        prev_step = 0
+        max_docs = num_docs + bulk_size if num_docs > bulk_size else bulk_size + 1
+        for next_step in xrange(bulk_size, max_docs, bulk_size):
+            logging.info('Indexing documents {} to {} of {} total on index {}.'.format(prev_step, next_step, num_docs, index_name))
+            bulk_index(src.get_es_instance(), [index_instance.serialize_object(doc) for doc in model_items[prev_step:next_step]], index=index_name, doc_type=model.__name__, raise_on_error=True)
+            prev_step = next_step
 
 def delete_index_item(item, model_name):
     '''
@@ -59,10 +60,13 @@ def delete_index_item(item, model_name):
     src = Bungiesearch()
 
     logging.info('Getting index for model {}.'.format(model_name))
-    index_name = src.get_index(model_name)
-    index_instance = src.get_model_index(model_name)
-    item_es_id = index_instance.fields['_id'].value(item)
-    src.get_es_instance().delete(index_name, model_name, item_es_id)
+    for index_name in src.get_index(model_name):
+        index_instance = src.get_model_index(model_name)
+        item_es_id = index_instance.fields['_id'].value(item)
+        try:
+            src.get_es_instance().delete(index_name, model_name, item_es_id)
+        except RequestError as e:
+            logging.warning('Could not delete {}.{} from index {}: {}.'.format(model_name, item_es_id, index_name, str(e)))
 
 def __str_to_tzdate__(date_str):
     return timezone.make_aware(parsedt(date_str), timezone.get_current_timezone())

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 from os.path import join, dirname
 from setuptools import setup, find_packages
 
-VERSION = (0, 0, 11)
+VERSION = (0, 1, 0)
 __version__ = VERSION
 __versionstr__ = '.'.join(map(str, VERSION))
 

--- a/tests/core/models.py
+++ b/tests/core/models.py
@@ -31,6 +31,14 @@ class NoUpdatedField(models.Model):
     class Meta:
         app_label = 'core'
 
+class ManangedButEmpty(models.Model):
+    title = models.TextField(db_index=True)
+    description = models.TextField(blank=True)
+
+    objects = BungiesearchManager()
+
+    class Meta:
+        app_label = 'core'
 
 class Unmanaged(models.Model):
     title = models.TextField(db_index=True)

--- a/tests/core/search_aliases.py
+++ b/tests/core/search_aliases.py
@@ -36,3 +36,12 @@ class ReturningSelfAlias(SearchAlias):
 
     class Meta:
         alias_name = 'get_alias_for_test'
+
+class BisIndex(SearchAlias):
+    def alias_for(self):
+        self.search_instance._index = 'bungiesearch_demo_bis'
+        return self.search_instance
+
+    class Meta:
+        models = (Article,)
+        alias_name = 'bisindex'

--- a/tests/core/search_indices_bis.py
+++ b/tests/core/search_indices_bis.py
@@ -1,12 +1,13 @@
 from bungiesearch.fields import DateField, StringField
 from bungiesearch.indices import ModelIndex
 
-from core.models import Article, NoUpdatedField
+from core.models import Article
 
 
 class ArticleIndex(ModelIndex):
     effective_date = DateField(eval_as='obj.created if obj.created and obj.published > obj.created else obj.published')
     meta_data = StringField(eval_as='" ".join([fld for fld in [obj.link, str(obj.tweet_count), obj.raw] if fld])')
+    more_fields = StringField(eval_as='"some value"')
 
     class Meta:
         model = Article
@@ -16,11 +17,4 @@ class ArticleIndex(ModelIndex):
                     'title': {'boost': 1.75},
                     'description': {'boost': 1.35},
                     'full_text': {'boost': 1.125}}
-        default = True
-
-class NoUpdatedFieldIndex(ModelIndex):
-    class Meta:
-        model = NoUpdatedField
-        exclude = ('description', )
-        optimize_queries = True
-        indexing_query = NoUpdatedField.objects.defer(*exclude).select_related().all()
+        default = False

--- a/tests/core/search_indices_bis.py
+++ b/tests/core/search_indices_bis.py
@@ -1,8 +1,7 @@
 from bungiesearch.fields import DateField, StringField
 from bungiesearch.indices import ModelIndex
 
-from core.models import Article
-
+from core.models import Article, ManangedButEmpty
 
 class ArticleIndex(ModelIndex):
     effective_date = DateField(eval_as='obj.created if obj.created and obj.published > obj.created else obj.published')
@@ -18,3 +17,13 @@ class ArticleIndex(ModelIndex):
                     'description': {'boost': 1.35},
                     'full_text': {'boost': 1.125}}
         default = False
+
+class EmptyIndex(ModelIndex):
+    def matches_indexing_condition(self, item):
+        return False
+
+    class Meta:
+        model = ManangedButEmpty
+        exclude = ('description',)
+        optimize_queries = True
+

--- a/tests/core/test_bungiesearch.py
+++ b/tests/core/test_bungiesearch.py
@@ -232,11 +232,8 @@ class ModelIndexTestCase(TestCase):
     def test_concat_queries(self):
         items = Article.objects.bsearch_title_search('title')[::True] + NoUpdatedField.objects.search.query('match', title='My title')[::True]
         for item in Bungiesearch.map_raw_results(sorted(items, key=attrgetter('title'))):
+            import pdb;pdb.set_trace()
             self.assertIn(type(item), [Article, NoUpdatedField], 'Got an unmapped item, or an item with an unexpected mapping.')
-
-    def test_bisindex(self):
-        items = Article.objects.bsearch_bisindex()[:]
-        import pdb;pdb.set_trace()
 
     def test_fun(self):
         '''
@@ -252,30 +249,3 @@ class ModelIndexTestCase(TestCase):
         '''
         lazy = Article.objects.bsearch_title_search('title').only('pk').fields('_id')
         assert all([hasattr(item._searchmeta) for item in lazy.filter('range', effective_date={'lte': '2014-09-22'})[5:7]])
-
-#class ModelIndexInitTestCase(TestCase):
-#    def testMultidefaults(self):
-#        '''
-#        Tests that creating several model indices all marked as default will raise an exception.
-#        '''
-#        from django.db import models
-#        from bungiesearch.managers import BungiesearchManager
-#        
-#        # Model.
-#        class M1(models.Model):
-#            title = models.TextField(db_index=True)
-#            #objects = BungiesearchManager()
-#            class Meta:
-#                app_label = 'core'
-#        
-#        class M1Index1(ModelIndex):
-#            class Meta:
-#                model = M1
-#                default = True
-#        
-#        class M1Index2(ModelIndex):
-#            class Meta:
-#                model = M1
-#                default = True
-#        
-#        import pdb;pdb.set_trace()

--- a/tests/core/test_bungiesearch.py
+++ b/tests/core/test_bungiesearch.py
@@ -260,3 +260,9 @@ class ModelIndexTestCase(TestCase):
         idxi = len(ManangedButEmpty.objects.search)
         self.assertEquals(idxi, 0, 'ManagedButEmpty has {} indexed items instead of zero.'.format(idxi))
         mbeo.delete()
+
+    def test_specify_index(self):
+        self.assertEqual(Article.objects.count(), Article.objects.search_index('bungiesearch_demo').count(), 'Indexed items on bungiesearch_demo for Article does not match number in database.')
+        self.assertEqual(Article.objects.count(), Article.objects.search_index('bungiesearch_demo_bis').count(), 'Indexed items on bungiesearch_demo_bis for Article does not match number in database.')
+        self.assertEqual(NoUpdatedField.objects.count(), NoUpdatedField.objects.search_index('bungiesearch_demo').count(), 'Indexed items on bungiesearch_demo for NoUpdatedField does not match number in database.')
+        self.assertEqual(NoUpdatedField.objects.search_index('bungiesearch_demo_bis').count(), 0, 'Indexed items on bungiesearch_demo_bis for NoUpdatedField is zero.')

--- a/tests/core/test_bungiesearch.py
+++ b/tests/core/test_bungiesearch.py
@@ -3,6 +3,7 @@ from operator import attrgetter
 from time import sleep
 
 from bungiesearch import Bungiesearch
+from bungiesearch.indices import ModelIndex
 from bungiesearch.management.commands import search_index
 from bungiesearch.utils import update_index
 from django.test import TestCase
@@ -233,6 +234,10 @@ class ModelIndexTestCase(TestCase):
         for item in Bungiesearch.map_raw_results(sorted(items, key=attrgetter('title'))):
             self.assertIn(type(item), [Article, NoUpdatedField], 'Got an unmapped item, or an item with an unexpected mapping.')
 
+    def test_bisindex(self):
+        items = Article.objects.bsearch_bisindex()[:]
+        import pdb;pdb.set_trace()
+
     def test_fun(self):
         '''
         Test fun queries.
@@ -247,3 +252,30 @@ class ModelIndexTestCase(TestCase):
         '''
         lazy = Article.objects.bsearch_title_search('title').only('pk').fields('_id')
         assert all([hasattr(item._searchmeta) for item in lazy.filter('range', effective_date={'lte': '2014-09-22'})[5:7]])
+
+#class ModelIndexInitTestCase(TestCase):
+#    def testMultidefaults(self):
+#        '''
+#        Tests that creating several model indices all marked as default will raise an exception.
+#        '''
+#        from django.db import models
+#        from bungiesearch.managers import BungiesearchManager
+#        
+#        # Model.
+#        class M1(models.Model):
+#            title = models.TextField(db_index=True)
+#            #objects = BungiesearchManager()
+#            class Meta:
+#                app_label = 'core'
+#        
+#        class M1Index1(ModelIndex):
+#            class Meta:
+#                model = M1
+#                default = True
+#        
+#        class M1Index2(ModelIndex):
+#            class Meta:
+#                model = M1
+#                default = True
+#        
+#        import pdb;pdb.set_trace()

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -27,7 +27,8 @@ MIDDLEWARE_CLASSES = ()
 DEFAULT_INDEX_TABLESPACE = ''
 BUNGIESEARCH = {
                 'URLS': [os.getenv('ELASTIC_SEARCH_URL')],
-                'INDICES': {'bungiesearch_demo': 'core.search_indices'},
+                'INDICES': {'bungiesearch_demo': 'core.search_indices',
+                            'bungiesearch_demo_bis': 'core.search_indices_bis'},
                 'ALIASES': {'bsearch': 'core.search_aliases'},
                 'SIGNALS': {'BUFFER_SIZE': 1},
                 'ES_SETTINGS': {'http_auth': os.getenv('ELASTIC_SEARCH_AUTH')},


### PR DESCRIPTION
First stable version, given Bungiesearch has been used in production on [Sparrho](http://sparrho.com) since October 2014.
# New Features since 0.0.11
+ Supports indexing a given Django model on several elasticsearch indices.
+ Supports specifying an indexing condition per ModelIndex, i.e. per Django model and elasticsearch index pair.
+ New Manager method allows specifying which index to use when searching: `search_index('index')`.

# Bug fixes
+ No longer crashes when attempting to delete an item which is not indexed.