### PR TITLE
Removed redundant slicing that caused incorrect results

### DIFF
--- a/bungiesearch/__init__.py
+++ b/bungiesearch/__init__.py
@@ -344,7 +344,7 @@ class Bungiesearch(Search):
                 return results[0]
             except IndexError:
                 return []
-        return results[key.start:key.stop]
+        return results
 
     def hook_alias(self, alias, model_obj=None):
         '''

--- a/tests/core/test_bungiesearch.py
+++ b/tests/core/test_bungiesearch.py
@@ -231,9 +231,10 @@ class ModelIndexTestCase(TestCase):
         self.assertEqual(src_item._meta.proxy_for_model, NoUpdatedField, 'Proxy for model of search item is not "NoUpdatedField".')
 
     def test_concat_queries(self):
-        items = Article.objects.bsearch_title_search('title')[::True] + NoUpdatedField.objects.search.query('match', title='My title')[::True]
-        for item in Bungiesearch.map_raw_results(sorted(items, key=attrgetter('title'))):
-            self.assertIn(type(item), [Article, NoUpdatedField], 'Got an unmapped item, or an item with an unexpected mapping.')
+        items = Article.objects.bsearch_title_search('title')[::False] + NoUpdatedField.objects.search.query('match', title='My title')[::False]
+        for item in items:
+            model = item._meta.proxy_for_model if item._meta.proxy_for_model else type(item)
+            self.assertIn(model, [Article, NoUpdatedField], 'Got an unmapped item ({}), or an item with an unexpected mapping.'.format(type(item)))
 
     def test_fun(self):
         '''


### PR DESCRIPTION
Currently slicing on a results set causes the results to be sliced twice:  once by elasticsearch_dsl and once by bungiesearch itself. This results in incorrectly, unexpected results being returned for many slicing attempts.

For instance, results[10:15] would cause elasticsearch_dsl to grab results 10 through 15 (for five total results), which bundiesearch then slices from 10 to 15, resulting in zero results.

This pull request removes the redundant slicing, allowing the correct results to be returned.