### PR TITLE
Adds PyPI support with LICENSE. Bungiesearch now in version 1.0.2.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /venv
 *.pyc
 
+/build/
+/bungiesearch.egg-info/
+/dist/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2014, Sparrho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of Sparrho nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -3,17 +3,18 @@ import sys
 from os.path import join, dirname
 from setuptools import setup, find_packages
 
-VERSION = (0, 1, 0)
+VERSION = (1, 0, 2)
 __version__ = VERSION
 __versionstr__ = '.'.join(map(str, VERSION))
 
-long_description = 'Should have been loaded.'
+long_description = 'Should have been loaded from README.md.'
 with open(join(dirname(__file__), 'README.md')) as f:
     long_description = f.read().strip()
 
 
 install_requires = [
-    'django',
+    'django>=1.6',
+    'elasticsearch-dsl<0.0.4',
     'python-dateutil',
 ]
 
@@ -25,9 +26,9 @@ if sys.version_info[:2] == (2, 6):
 
 setup(
     name="bungiesearch",
-    description="A Django elasticsearch wrapper using elasticsearch's elasticsearch-dsl-py high level library.",
-    license="To be determined I guess",
-    url="https://github.com/sparrho/bungiesearch?",
+    description="A Django elasticsearch wrapper and helper using elasticsearch-dsl-py high level library.",
+    license="BSD-3",
+    url="https://github.com/sparrho/bungiesearch",
     long_description=long_description,
     version=__versionstr__,
     author="Christopher Rabotin",
@@ -37,11 +38,15 @@ setup(
         exclude=('bungiesearch/tests',)
     ),
     classifiers=[
-        "Development Status :: 2 - Pre-Alpha",
+        "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
+        "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 3",
+        "Framework :: Django"
     ],
+    keywords="elasticsearch haystack django bungiesearch sparrho",
     install_requires=install_requires,
-    dependency_links = ['https://github.com/elasticsearch/elasticsearch-dsl-py#egg=elasticsearch-dsl-py'],
+    dependency_links=['https://github.com/elasticsearch/elasticsearch-dsl-py#egg=elasticsearch-dsl-py'],
 )

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,7 +3,7 @@ bungiesearch
 cov-core==1.14.0
 coverage==3.7.1
 elasticsearch==1.2.0
--e git+https://github.com/elasticsearch/elasticsearch-dsl-py@9cf802968d857e9788a6ee2746423453bf16082f#egg=elasticsearch_dsl-master
+elasticsearch-dsl==0.0.3
 pytz==2014.7
 six==1.8.0
 urllib3==1.9


### PR DESCRIPTION
Implements #71.

*Note:* this is version 1.0.2 because I had a typo in the setup.py file, and could not overwrite the distribution package.