### PR TITLE
Make bungiesearch compatible with elasticsearch-dsl 0.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ from datetime import datetime
 class ArticleIndex(ModelIndex):
 
     def matches_indexing_condition(self, item):
-        return item.updated < datetime.datetime(2015, 9, 21, 4, 29)
+        return item.updated < datetime.datetime(2015, 10, 21, 4, 29)
 
     class Meta:
         model = Article

--- a/bungiesearch/__init__.py
+++ b/bungiesearch/__init__.py
@@ -168,13 +168,13 @@ class Bungiesearch(Search):
             results = [None] * len(raw_results)
         found_results = {}
         for pos, result in enumerate(raw_results):
-            model_name = result._meta.doc_type
-            if model_name not in Bungiesearch._model_name_to_index or result._meta.index not in Bungiesearch._model_name_to_index[model_name]:
+            model_name = result.meta.doc_type
+            if model_name not in Bungiesearch._model_name_to_index or result.meta.index not in Bungiesearch._model_name_to_index[model_name]:
                 logging.warning('Returned object of type {} ({}) is not defined in the settings, or is not associated to the same index as in the settings.'.format(model_name, result))
                 results[pos] = result
             else:
-                model_results['{}.{}'.format(result._meta.index, model_name)].append(result.id)
-                found_results['{1._meta.index}.{0}.{1.id}'.format(model_name, result)] = (pos, result._meta)
+                model_results['{}.{}'.format(result.meta.index, model_name)].append(result.id)
+                found_results['{1.meta.index}.{0}.{1.id}'.format(model_name, result)] = (pos, result.meta)
 
         # Now that we have model ids per model name, let's fetch everything at once.
         for ref_name, ids in model_results.iteritems():

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(join(dirname(__file__), 'README.md')) as f:
 
 install_requires = [
     'django>=1.6',
-    'elasticsearch-dsl<0.0.4',
+    'elasticsearch-dsl>=0.0.4',
     'python-dateutil',
 ]
 

--- a/tests/core/test_bungiesearch.py
+++ b/tests/core/test_bungiesearch.py
@@ -81,7 +81,7 @@ class ModelIndexTestCase(TestCase):
         Test searching and mapping.
         '''
         item = Article.objects.search.query('match', _all='Description')[:1:True]
-        self.assertTrue(hasattr(item, 'meta'), 'Fetching first raw results did not return an object with a _meta attribute.')
+        self.assertTrue(hasattr(item, 'meta'), 'Fetching first raw results did not return an object with a meta attribute.')
 
     def test_iteration(self):
         '''

--- a/tests/core/test_bungiesearch.py
+++ b/tests/core/test_bungiesearch.py
@@ -81,7 +81,7 @@ class ModelIndexTestCase(TestCase):
         Test searching and mapping.
         '''
         item = Article.objects.search.query('match', _all='Description')[:1:True]
-        self.assertTrue(hasattr(item, '_meta'), 'Fetching first raw results did not return an object with a _meta attribute.')
+        self.assertTrue(hasattr(item, 'meta'), 'Fetching first raw results did not return an object with a _meta attribute.')
 
     def test_iteration(self):
         '''
@@ -175,7 +175,7 @@ class ModelIndexTestCase(TestCase):
         find_three = Article.objects.search.query('match', title='three')
         self.assertEqual(len(find_three), 2, 'Searching for "three" in title did not return exactly two items (got {}).'.format(find_three))
         # Let's check that both returned items are from different indices.
-        self.assertNotEqual(find_three[0:1:True]._meta.index, find_three[1:2:True]._meta.index, 'Searching for "three" did not return items from different indices.')
+        self.assertNotEqual(find_three[0:1:True].meta.index, find_three[1:2:True].meta.index, 'Searching for "three" did not return items from different indices.')
         # Let's now delete this object to test the post delete signal.
         obj.delete()
         print 'Sleeping two seconds for Elasticsearch to update its index after deleting an item.'

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,7 +3,7 @@ bungiesearch
 cov-core==1.14.0
 coverage==3.7.1
 elasticsearch==1.2.0
-elasticsearch-dsl==0.0.3
+elasticsearch-dsl==0.0.4
 pytz==2014.7
 six==1.8.0
 urllib3==1.9


### PR DESCRIPTION
It appears that elasticsearch-dsl changed the meta fields in docs and result to .meta (instead of the previously used ._meta (see links below). 
https://github.com/elastic/elasticsearch-dsl-py/commit/bf7f323c783cee14aa5a48c609dc42f26836e217
http://elasticsearch-dsl.readthedocs.org/en/latest/Changelog.html
This change makes bungiesearch compatible with elasticsearch-dsl 0.0.4.
(+ tiny change to typo in the documentation)