### PR TITLE
Add ability to create custom signal processing classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ In the example above, each search alias defined in `myproject.search_aliases` wi
 The purpose is to not accidently overwrite Django's default manager functions with search aliases.
 
 ### SIGNALS
-*Optional:* if it exists, it must be a dictionary (even empty), and will connect to the `post save` and `pre delete` model functions of *all* models using `bungiesearch.managers.BungiesearchManager` as a manager. One may also define a signal processor class for more custom functionality by placing the string value of the module path under a key called `CLASS_NAME` in the dictionary value of `SIGNALS` and defining a setup() method that connects to django signals.
+*Optional:* if it exists, it must be a dictionary (even empty), and will connect to the `post save` and `pre delete` model functions of *all* models using `bungiesearch.managers.BungiesearchManager` as a manager. One may also define a signal processor class for more custom functionality by placing the string value of the module path under a key called `CLASS_NAME` in the dictionary value of `SIGNALS` and defining a `setup` method that connects to django signals (signals are connected to each model which uses a BungiesearchManager).
 
 If `SIGNALS` is not defined in the settings, *none* of the models managed by BungiesearchManager will automatically update the index when a new item is created or deleted.
 
@@ -391,7 +391,7 @@ BUNGIESEARCH = {
                 'URLS': [os.getenv('ELASTIC_SEARCH_URL')],
                 'INDICES': {'bungiesearch_demo': 'core.search_indices'},
                 'ALIASES': {'bsearch': 'myproject.search_aliases'},
-                'SIGNALS': {'BUFFER_SIZE': 1}
+                'SIGNALS': {'BUFFER_SIZE': 1}  # uses BungieSignalProcessor
                 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ In the example above, each search alias defined in `myproject.search_aliases` wi
 The purpose is to not accidently overwrite Django's default manager functions with search aliases.
 
 ### SIGNALS
-*Optional:* if it exists, it must be a dictionary (even empty), and will connect to the `post save` and `pre delete` model functions of *all* models using `bungiesearch.managers.BungiesearchManager` as a manager. One may also define a signal processor class for more custom functionality by placing the string value of the module path under a key called `CLASS_NAME` in the dictionary value of `SIGNALS` and defining a `setup` method that connects to django signals (signals are connected to each model which uses a BungiesearchManager).
+*Optional:* if it exists, it must be a dictionary (even empty), and will connect to the `post save` and `pre delete` model functions of *all* models using `bungiesearch.managers.BungiesearchManager` as a manager. One may also define a signal processor class for more custom functionality by placing the string value of the module path under a key called `SIGNAL_CLASS` in the dictionary value of `SIGNALS` and defining `setup` and `teardown` methods, which take `model` as the only parameter. These methods connect and disconnect the signal processing class to django signals (signals are connected to each model which uses a BungiesearchManager).
 
 If `SIGNALS` is not defined in the settings, *none* of the models managed by BungiesearchManager will automatically update the index when a new item is created or deleted.
 

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ In the example above, each search alias defined in `myproject.search_aliases` wi
 The purpose is to not accidently overwrite Django's default manager functions with search aliases.
 
 ### SIGNALS
-*Optional:* if it exists, it must be a dictionary (even empty), and will connect to the `post save` and `pre delete` model functions of *all* models using `bungiesearch.managers.BungiesearchManager` as a manager.
+*Optional:* if it exists, it must be a dictionary (even empty), and will connect to the `post save` and `pre delete` model functions of *all* models using `bungiesearch.managers.BungiesearchManager` as a manager. One may also define a signal processor class for more custom functionality by placing the string value of the module path under a key called `CLASS_NAME` in the dictionary value of `SIGNALS` and defining a setup() method that connects to django signals.
 
 If `SIGNALS` is not defined in the settings, *none* of the models managed by BungiesearchManager will automatically update the index when a new item is created or deleted.
 

--- a/bungiesearch/managers.py
+++ b/bungiesearch/managers.py
@@ -1,4 +1,4 @@
-from django.db.models import Manager, signals
+from django.db.models import Manager
 import logging
 
 class BungiesearchManager(Manager):
@@ -27,12 +27,11 @@ class BungiesearchManager(Manager):
         super(BungiesearchManager, self).__init__(**kwargs)
 
         from . import Bungiesearch
-        from .signals import post_save_connector, pre_delete_connector
+        from .signals import get_signal_processor
         settings = Bungiesearch.BUNGIE
         if 'SIGNALS' in settings:
-            signals.post_save.connect(post_save_connector, sender=self.model)
-            signals.pre_delete.connect(pre_delete_connector, sender=self.model)
-        Bungiesearch._managed_models.append(self.model)
+            self.signal_processor = get_signal_processor()
+            self.signal_processor.setup(model=self.model)
 
     def __getattr__(self, alias):
         '''

--- a/bungiesearch/signals.py
+++ b/bungiesearch/signals.py
@@ -1,31 +1,55 @@
 from _collections import defaultdict
+
+from django.db.models import signals
+from importlib import import_module
+
 from . import Bungiesearch
 from .utils import update_index, delete_index_item
 
+def get_signal_processor():
+    signals = Bungiesearch.BUNGIE['SIGNALS']
+    if 'SIGNAL_CLASS' in signals:
+        module_str      = signals['SIGNAL_CLASS']
+        signal_module   = import_module(module_str)
+        signal_instance = signal_module()
+    else:
+        signal_instance = BungieSignalProcessor()
+
+    return signal_instance
 
 __items_to_be_indexed__ = defaultdict(list)
-def post_save_connector(sender, instance, **kwargs):
-    try:
-        Bungiesearch.get_index(sender, via_class=True)
-    except KeyError:
-        return # This model is not managed by Bungiesearch.
+class BungieSignalProcessor(object):
 
-    try:
-        buffer_size = Bungiesearch.BUNGIE['SIGNALS']['BUFFER_SIZE']
-    except KeyError:
-        buffer_size = 100
+    def post_save_connector(self, sender, instance, **kwargs):
+        try:
+            Bungiesearch.get_index(sender, via_class=True)
+        except KeyError:
+            return # This model is not managed by Bungiesearch.
 
-    __items_to_be_indexed__[sender].append(instance)
+        try:
+            buffer_size = Bungiesearch.BUNGIE['SIGNALS']['BUFFER_SIZE']
+        except KeyError:
+            buffer_size = 100
 
-    if len(__items_to_be_indexed__[sender]) >= buffer_size:
-        update_index(__items_to_be_indexed__[sender], sender.__name__, buffer_size)
-        # Let's now empty this buffer or we'll end up reindexing every item which was previously buffered.s
-        __items_to_be_indexed__[sender] = []
+        __items_to_be_indexed__[sender].append(instance)
 
-def pre_delete_connector(sender, instance, **kwargs):
-    try:
-        Bungiesearch.get_index(sender, via_class=True)
-    except KeyError:
-        return # This model is not managed by Bungiesearch.
+        if len(__items_to_be_indexed__[sender]) >= buffer_size:
+            update_index(__items_to_be_indexed__[sender], sender.__name__, buffer_size)
+            # Let's now empty this buffer or we'll end up reindexing every item which was previously buffered.
+            __items_to_be_indexed__[sender] = []
+    
+    def pre_delete_connector(self, sender, instance, **kwargs):
+        try:
+            Bungiesearch.get_index(sender, via_class=True)
+        except KeyError:
+            return # This model is not managed by Bungiesearch.
 
-    delete_index_item(instance, sender.__name__)
+        delete_index_item(instance, sender.__name__)
+    
+    def setup(self, model):
+        signals.post_save.connect(self.post_save_connector, sender=model)
+        signals.pre_delete.connect(self.pre_delete_connector, sender=model)
+
+    def teardown(self, model):
+        signals.post_save.disconnect(self.post_save_connector, sender=model)
+        signals.pre_delete.disconnect(self.pre_delete_connector, sender=model)

--- a/bungiesearch/signals.py
+++ b/bungiesearch/signals.py
@@ -9,10 +9,13 @@ from .utils import update_index, delete_index_item
 def get_signal_processor():
     signals = Bungiesearch.BUNGIE['SIGNALS']
     if 'SIGNAL_CLASS' in signals:
-        signal_module = import_module(signals['SIGNAL_CLASS'])
+        signal_path   = signals['SIGNAL_CLASS'].split('.')
+        signal_module = import_module('.'.join(signal_path[:-1]))
+        class_name    = signal_path[-1]
+        signal_class  = getattr(signal_module, class_name)
     else:
-        signal_module = BungieSignalProcessor
-    return signal_module()
+        signal_class = BungieSignalProcessor
+    return signal_class()
 
 __items_to_be_indexed__ = defaultdict(list)
 class BungieSignalProcessor(object):

--- a/bungiesearch/signals.py
+++ b/bungiesearch/signals.py
@@ -9,10 +9,9 @@ from .utils import update_index, delete_index_item
 def get_signal_processor():
     signals = Bungiesearch.BUNGIE['SIGNALS']
     if 'SIGNAL_CLASS' in signals:
-        signal_path   = signals['SIGNAL_CLASS'].split('.')
+        signal_path = signals['SIGNAL_CLASS'].split('.')
         signal_module = import_module('.'.join(signal_path[:-1]))
-        class_name    = signal_path[-1]
-        signal_class  = getattr(signal_module, class_name)
+        signal_class = getattr(signal_module, signal_path[-1])
     else:
         signal_class = BungieSignalProcessor
     return signal_class()

--- a/bungiesearch/signals.py
+++ b/bungiesearch/signals.py
@@ -9,13 +9,10 @@ from .utils import update_index, delete_index_item
 def get_signal_processor():
     signals = Bungiesearch.BUNGIE['SIGNALS']
     if 'SIGNAL_CLASS' in signals:
-        module_str      = signals['SIGNAL_CLASS']
-        signal_module   = import_module(module_str)
-        signal_instance = signal_module()
+        signal_module = import_module(signals['SIGNAL_CLASS'])
     else:
-        signal_instance = BungieSignalProcessor()
-
-    return signal_instance
+        signal_module = BungieSignalProcessor
+    return signal_module()
 
 __items_to_be_indexed__ = defaultdict(list)
 class BungieSignalProcessor(object):
@@ -51,5 +48,5 @@ class BungieSignalProcessor(object):
         signals.pre_delete.connect(self.pre_delete_connector, sender=model)
 
     def teardown(self, model):
-        signals.post_save.disconnect(self.post_save_connector, sender=model)
         signals.pre_delete.disconnect(self.pre_delete_connector, sender=model)
+        signals.post_save.disconnect(self.post_save_connector, sender=model)

--- a/tests/core/bungie_signal.py
+++ b/tests/core/bungie_signal.py
@@ -1,5 +1,11 @@
+from _collections import defaultdict
+
 from django.db.models import signals
 
+from bungiesearch import Bungiesearch
+from bungiesearch.utils import update_index, delete_index_item
+
+__items_to_be_indexed__ = defaultdict(list)
 class BungieTestSignalProcessor(object):
 
     def handle_save(self, sender, instance, **kwargs):
@@ -29,9 +35,9 @@ class BungieTestSignalProcessor(object):
         delete_index_item(instance, sender.__name__)
 
     def setup(self, model):
-        signals.post_save.connect(self.handle_save)
-        signals.pre_delete.connect(self.handle_delete)
+        signals.post_save.connect(self.handle_save, sender=model)
+        signals.pre_delete.connect(self.handle_delete, sender=model)
 
     def teardown(self):
-        signals.pre_delete.disconnect(self.handle_delete)
-        signals.post_save.disconnect(self.handle_save)
+        signals.pre_delete.disconnect(self.handle_delete, sender=model)
+        signals.post_save.disconnect(self.handle_save, sender=model)

--- a/tests/core/bungie_signal.py
+++ b/tests/core/bungie_signal.py
@@ -1,0 +1,37 @@
+from django.db.models import signals
+
+class BungieTestSignalProcessor(object):
+
+    def handle_save(self, sender, instance, **kwargs):
+        try:
+            Bungiesearch.get_index(sender, via_class=True)
+        except KeyError:
+            return # This model is not managed by Bungiesearch.
+
+        try:
+            buffer_size = Bungiesearch.BUNGIE['SIGNALS']['BUFFER_SIZE']
+        except KeyError:
+            buffer_size = 100
+
+        __items_to_be_indexed__[sender].append(instance)
+
+        if len(__items_to_be_indexed__[sender]) >= buffer_size:
+            update_index(__items_to_be_indexed__[sender], sender.__name__, buffer_size)
+            # Let's now empty this buffer or we'll end up reindexing every item which was previously buffered.
+            __items_to_be_indexed__[sender] = []
+
+    def handle_delete(self, sender, instance, **kwargs):
+        try:
+            Bungiesearch.get_index(sender, via_class=True)
+        except KeyError:
+            return # This model is not managed by Bungiesearch.
+
+        delete_index_item(instance, sender.__name__)
+
+    def setup(self, model):
+        signals.post_save.connect(self.handle_save)
+        signals.pre_delete.connect(self.handle_delete)
+
+    def teardown(self):
+        signals.pre_delete.disconnect(self.handle_delete)
+        signals.post_save.disconnect(self.handle_save)

--- a/tests/core/test_bungiesearch.py
+++ b/tests/core/test_bungiesearch.py
@@ -231,6 +231,31 @@ class ModelIndexTestCase(TestCase):
         print 'Sleeping two seconds for Elasticsearch to update its index after deleting an item.'
         sleep(2) # Without this we query elasticsearch before it has analyzed the newly committed changes, so it doesn't return any result.
 
+    def test_post_save_custom_class(self):
+        Bungiesearch.BUNGIE['SIGNALS']['SIGNAL_CLASS'] = 'tests.core.bungie_signal.BungieTestSignalProcessor'
+        art = {'title': 'Title four',
+                 'description': 'Postsave custom signal processing class',
+                 'link': 'http://example.com/sparrho',
+                 'published': pytz.UTC.localize(datetime(year=2020, month=9, day=15)),
+                 'updated': pytz.UTC.localize(datetime(year=2014, month=9, day=10)),
+                 'tweet_count': 20,
+                 'source_hash': 159159159159,
+                 'missing_data': '',
+                 'positive_feedback': 50,
+                 'negative_feedback': 5,
+                 }
+        obj = Article.objects.create(**art)
+        print 'Sleeping two seconds for Elasticsearch to index new item.'
+        sleep(2) # Without this we query elasticsearch before it has analyzed the newly committed changes, so it doesn't return any result.
+        find_four = Article.objects.search.query('match', title='three')
+        self.assertEqual(len(find_four), 2, 'Searching for "three" in title did not return exactly two items (got {}).'.format(find_four))
+        # Let's check that both returned items are from different indices.
+        self.assertNotEqual(find_four[0:1:True].meta.index, find_four[1:2:True].meta.index, 'Searching for "three" did not return items from different indices.')
+        # Let's now delete this object to test the post delete signal.
+        obj.delete()
+        print 'Sleeping two seconds for Elasticsearch to update its index after deleting an item.'
+        sleep(2) # Without this we query elasticsearch before it has analyzed the newly committed changes, so it doesn't return any result.
+
     def test_serialize_object(self):
         expected = {'Title one': {'updated': pytz.UTC.localize(datetime.strptime('2014-09-10', '%Y-%m-%d')),
                                   'published': pytz.UTC.localize(datetime.strptime('2020-09-15', '%Y-%m-%d')),

--- a/tests/core/test_bungiesearch.py
+++ b/tests/core/test_bungiesearch.py
@@ -232,7 +232,7 @@ class ModelIndexTestCase(TestCase):
         sleep(2) # Without this we query elasticsearch before it has analyzed the newly committed changes, so it doesn't return any result.
 
     def test_post_save_custom_class(self):
-        Bungiesearch.BUNGIE['SIGNALS']['SIGNAL_CLASS'] = 'tests.core.bungie_signal.BungieTestSignalProcessor'
+        Bungiesearch.BUNGIE['SIGNALS']['SIGNAL_CLASS'] = 'core.bungie_signal.BungieTestSignalProcessor'
         art = {'title': 'Title four',
                  'description': 'Postsave custom signal processing class',
                  'link': 'http://example.com/sparrho',
@@ -244,15 +244,19 @@ class ModelIndexTestCase(TestCase):
                  'positive_feedback': 50,
                  'negative_feedback': 5,
                  }
+        print ("ART", art)
+        print Bungiesearch.BUNGIE
         obj = Article.objects.create(**art)
         print 'Sleeping two seconds for Elasticsearch to index new item.'
         sleep(2) # Without this we query elasticsearch before it has analyzed the newly committed changes, so it doesn't return any result.
-        find_four = Article.objects.search.query('match', title='three')
+        find_four = Article.objects.search.query('match', title='four')
+        print ("LEN", len(find_four))
         self.assertEqual(len(find_four), 2, 'Searching for "three" in title did not return exactly two items (got {}).'.format(find_four))
         # Let's check that both returned items are from different indices.
         self.assertNotEqual(find_four[0:1:True].meta.index, find_four[1:2:True].meta.index, 'Searching for "three" did not return items from different indices.')
         # Let's now delete this object to test the post delete signal.
         obj.delete()
+        del Bungiesearch.BUNGIE['SIGNALS']['SIGNAL_CLASS']
         print 'Sleeping two seconds for Elasticsearch to update its index after deleting an item.'
         sleep(2) # Without this we query elasticsearch before it has analyzed the newly committed changes, so it doesn't return any result.
 

--- a/tests/core/test_bungiesearch.py
+++ b/tests/core/test_bungiesearch.py
@@ -244,13 +244,10 @@ class ModelIndexTestCase(TestCase):
                  'positive_feedback': 50,
                  'negative_feedback': 5,
                  }
-        print ("ART", art)
-        print Bungiesearch.BUNGIE
         obj = Article.objects.create(**art)
         print 'Sleeping two seconds for Elasticsearch to index new item.'
         sleep(2) # Without this we query elasticsearch before it has analyzed the newly committed changes, so it doesn't return any result.
         find_four = Article.objects.search.query('match', title='four')
-        print ("LEN", len(find_four))
         self.assertEqual(len(find_four), 2, 'Searching for "three" in title did not return exactly two items (got {}).'.format(find_four))
         # Let's check that both returned items are from different indices.
         self.assertNotEqual(find_four[0:1:True].meta.index, find_four[1:2:True].meta.index, 'Searching for "three" did not return items from different indices.')

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -4,6 +4,7 @@ import sys
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 # Make sure the copy of seeker in the directory above this one is used.
+
 sys.path.insert(0, BASE_DIR)
 SECRET_KEY = 'cookies_are_delicious_delicacies'
 INSTALLED_APPS = (

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -4,7 +4,6 @@ import sys
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 # Make sure the copy of seeker in the directory above this one is used.
-
 sys.path.insert(0, BASE_DIR)
 SECRET_KEY = 'cookies_are_delicious_delicacies'
 INSTALLED_APPS = (


### PR DESCRIPTION
The ability to create and utilize custom signal processing classes is something I needed given the complexity of the signal processing (and it's relationship with task management) that we currently support. I have packaged the signal processing functions into a default class called BungieSignalProcessor and configured the managers document to reflect these changes. The user can now create their own signal processor and use it with Bungiesearch by placing the key 'SIGNAL_CLASS' (and the string value of the module for signal processing) in settings['SIGNALS']. The default behavior without this key-value pair is the use of BungieSignalProcessor (and, as before, if signals is not defined in settings, no automatic updates). I've tried my best to reflect these changes as concisely as possible in the README.