### PR TITLE
Add the ability to use custom analyzers in bungiesearch.

### DIFF
--- a/bungiesearch/fields.py
+++ b/bungiesearch/fields.py
@@ -1,6 +1,8 @@
 from django.template.defaultfilters import striptags
 from six import iteritems
 
+from elasticsearch_dsl.analysis import Analyzer
+
 
 class AbstractField(object):
     '''
@@ -78,8 +80,16 @@ class AbstractField(object):
         return getattr(obj, self.model_attr)
 
     def json(self):
-        return dict((attr, val) for attr, val in iteritems(self.__dict__) if attr not in ['eval_func', 'model_attr'])
+        json = {}
+        for attr, val in iteritems(self.__dict__):
+            if attr in ('eval_func', 'model_attr', 'template_name'):
+                continue
+            elif attr in ('analyzer', 'index_analyzer', 'search_analyzer') and isinstance(val, Analyzer):
+                json[attr] = val.to_dict()
+            else:
+                json[attr] = val
 
+        return json
 # All the following definitions could probably be done with better polymorphism.
 
 class StringField(AbstractField):

--- a/bungiesearch/indices.py
+++ b/bungiesearch/indices.py
@@ -3,6 +3,8 @@ import logging
 from bungiesearch.fields import AbstractField, django_field_to_index
 from six import iteritems
 
+from elasticsearch_dsl.analysis import Analyzer
+
 
 class ModelIndex(object):
     '''
@@ -69,6 +71,30 @@ class ModelIndex(object):
         :return: a dictionary which can be used to generate the elasticsearch index mapping for this doctype.
         '''
         return {'properties': dict((name, field.json()) for name, field in iteritems(self.fields))}
+
+    def collect_analysis(self):
+        '''
+        :return: a dictionary which is used to get the serialized analyzer definition from the analyzer class.
+        '''
+        analysis = {}    
+        for field in self.fields.values():
+            for analyzer_name in ('analyzer', 'index_analyzer', 'search_analyzer'):
+                if not hasattr(field, analyzer_name):
+                    continue
+
+                analyzer = getattr(field, analyzer_name)
+
+                if not isinstance(analyzer, Analyzer):
+                    continue
+
+                d = analyzer.get_analysis_definition()
+                if not d:
+                    continue
+
+                for key in d:
+                    analysis.setdefault(key, {}).update(d[key])
+
+        return analysis
 
     def serialize_object(self, obj, obj_pk=None):
         '''

--- a/bungiesearch/indices.py
+++ b/bungiesearch/indices.py
@@ -87,12 +87,12 @@ class ModelIndex(object):
                 if not isinstance(analyzer, Analyzer):
                     continue
 
-                d = analyzer.get_analysis_definition()
-                if not d:
+                definition = analyzer.get_analysis_definition()
+                if definition is None:
                     continue
 
-                for key in d:
-                    analysis.setdefault(key, {}).update(d[key])
+                for key in definition:
+                    analysis.setdefault(key, {}).update(definition[key])
 
         return analysis
 

--- a/bungiesearch/management/commands/search_index.py
+++ b/bungiesearch/management/commands/search_index.py
@@ -132,9 +132,11 @@ class Command(BaseCommand):
                 mapping = {}
                 for mdl_idx in src.get_model_indices(index):
                     mapping[mdl_idx.get_model().__name__] = mdl_idx.get_mapping()
-
+                
+                analysis = mdl_idx.collect_analysis()
+                
                 logging.info('Creating index {} with {} doctypes.'.format(index, len(mapping)))
-                es.indices.create(index=index, body={'mappings': mapping})
+                es.indices.create(index=index, body={'mappings': mapping, 'settings': {'analysis': analysis}})
 
         elif options['action'] == 'update-mapping':
             if options['index']:

--- a/tests/core/analysis.py
+++ b/tests/core/analysis.py
@@ -1,0 +1,16 @@
+from elasticsearch_dsl.analysis import analyzer, token_filter
+
+edge_ngram_analyzer = analyzer(
+  'edge_ngram_analyzer',
+  type='custom',
+  tokenizer='standard',
+  filter=[
+    'lowercase',
+    token_filter(
+      'edge_ngram_filter',
+      type='edgeNGram',
+      min_gram=2,
+      max_gram=20
+    )
+  ]
+)

--- a/tests/core/search_indices.py
+++ b/tests/core/search_indices.py
@@ -3,6 +3,8 @@ from bungiesearch.indices import ModelIndex
 
 from core.models import Article, User, NoUpdatedField
 
+from .analysis import edge_ngram_analyzer
+
 
 class ArticleIndex(ModelIndex):
     effective_date = DateField(eval_as='obj.created if obj.created and obj.published > obj.created else obj.published')
@@ -21,6 +23,7 @@ class ArticleIndex(ModelIndex):
 
 class UserIndex(ModelIndex):
     effective_date = DateField(eval_as='obj.created if obj.created and obj.updated > obj.created else obj.updated')
+    description = StringField(model_attr='description', analyzer=edge_ngram_analyzer)
 
     class Meta:
         model = User

--- a/tests/core/test_bungiesearch.py
+++ b/tests/core/test_bungiesearch.py
@@ -82,7 +82,7 @@ class CoreTestCase(TestCase):
                                            'published': {'type': 'date'}}
                            }
         expected_user = {'properties': {'updated': {'type': 'date'},
-                                        'description': {'type': 'string', 'analyzer': 'snowball'},
+                                        'description': {'type': 'string', 'analyzer': 'edge_ngram_analyzer'},
                                         'user_id': {'analyzer': 'snowball', 'type': 'string'},
                                         'effective_date': {'type': 'date'},
                                         'created': {'type': 'date'},


### PR DESCRIPTION
In the past, bungiesearch did not support the ability to use custom analyzers. When you plugged a custom analyzer into the index fields, you would get a SerializationError, because the Custom Analyzer was a class. Now, the indices will return the custom analyzer name in the mapping, while the settings for the field will be directly changed to reflect the use of the analyzer. The collect_analysis function borrows liberally from elasticsearch_dsl, and the mechanism for changing the settings is also a reflection of the elasticsearch_dsl implementation.