### PR TITLE
Fix indexing_query in update command

### DIFF
--- a/bungiesearch/indices.py
+++ b/bungiesearch/indices.py
@@ -40,6 +40,7 @@ class ModelIndex(object):
         self.updated_field = getattr(_meta, 'updated_field', None)
         self.optimize_queries = getattr(_meta, 'optimize_queries', False)
         self.is_default = getattr(_meta, 'default', True)
+        self.indexing_query = getattr(_meta, 'indexing_query', None)
 
         # Add in fields from the model.
         self.fields.update(self._get_fields(fields, excludes, hotfixes))

--- a/bungiesearch/management/commands/search_index.py
+++ b/bungiesearch/management/commands/search_index.py
@@ -174,7 +174,7 @@ class Command(BaseCommand):
                 model_names = [model for index in src.get_indices() for model in src.get_models(index)]
             # Update index.
             for model_name in model_names:
-                if hasattr(src.get_model_index(model_name), 'indexing_query'):
+                if src.get_model_index(model_name).indexing_query is not None:
                     update_index(src.get_model_index(model_name).indexing_query, model_name, bulk_size=options['bulk_size'], num_docs=options['num_docs'], start_date=options['start_date'], end_date=options['end_date'])
                 else:
                     update_index(src.get_model_index(model_name).get_model().objects.all(), model_name, bulk_size=options['bulk_size'], num_docs=options['num_docs'], start_date=options['start_date'], end_date=options['end_date'])


### PR DESCRIPTION
This will be one of a series of 2 or 3 PRs coming in today, and they will be my last of this summer. I would *really* appreciate if you could merge these and put out a release of bungiesearch by the end of the day on Friday - these are really tying up loose ends rather than major features. It's been a pleasure working with this project! I also wrote a celery signal processor for bungiesearch this summer as well, and you can check that out here: https://github.com/afrancis13/celery-bungiesearch. Feel free to take a look and use it/recommend it if you see a situation that fits the use case. I will make a second release of this as soon as the newest version of bungiesearch is released. Thanks for everything!

-

Previously, on update:
if hasattr(src.get_model_index(model_name), 'indexing_query')

Of course, this is never True, because 'indexing_query' never gets put on the model index, so you would need to do something like:
if hasattr(src.get_model_index(model_name).Meta, 'indexing_query')

However, to keep consistent with the project, I abstracted the detail of this into the indices.py document with _meta.