### PR TITLE
Add prepare_{} field evaluation

### DIFF
--- a/tests/core/search_indices.py
+++ b/tests/core/search_indices.py
@@ -1,4 +1,4 @@
-from bungiesearch.fields import DateField, StringField
+from bungiesearch.fields import DateField, NumberField, StringField
 from bungiesearch.indices import ModelIndex
 
 from core.models import Article, User, NoUpdatedField
@@ -25,6 +25,15 @@ class ArticleIndex(ModelIndex):
 class UserIndex(ModelIndex):
     effective_date = DateField(eval_as='obj.created if obj.created and obj.updated > obj.created else obj.updated')
     description = StringField(model_attr='description', analyzer=edge_ngram_analyzer)
+    int_description = NumberField(coretype='integer')
+
+    def prepare_int_description(self, obj):
+        try:
+            int_description = int(obj.description)
+        except ValueError:
+            int_description = 1
+
+        return int_description
 
     class Meta:
         model = User


### PR DESCRIPTION
Haystack has this cool feature where you can declare a function called prepare_{ }, where the thing in brackets is the name of the field and the field evaluates to the evaluation of that function for that object (see example in tests below). This is sort of like the `eval_as` function that already exists in Bungiesearch, but it's not as limited (you can use imports + other things from the index, and supports multiline logic - try/except, etc.). Since we need to do some exception handling and use imports in our version of `search_indices.py`, this is an important feature for us. So, I rewrote the serializer a bit, reorganized the error handling code, and wrote a test that passes.

I also added functionality that would evaluate a field as a method call if it was callable (also borrow from Haystack), and delayed the definition of `self.fields['_id']` (in `indices.py`) until after class level fields have been evaluated.