### PR TITLE
Additional management commands for bungiesearch

### DIFF
--- a/bungiesearch/management/commands/clear_index.py
+++ b/bungiesearch/management/commands/clear_index.py
@@ -1,0 +1,34 @@
+import sys
+from optparse import make_option
+
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+
+from django.utils import six
+
+
+class Command(BaseCommand):
+    help = 'Clears the search index of its contents.'
+
+    option_list = BaseCommand.option_list + (
+        make_option('--noinput',
+            action='store_false',
+            dest='interactive',
+            default=True,
+            help='If provided, no prompts will be issued to the user and the data will be wiped out'),
+       )
+
+    def handle(self, **options):
+        if options.get('interactive', True):
+            print("WARNING: This will irreparably remove EVERYTHING from your search index.")
+            print("Your choices after this are to restore from backups or rebuild via the `rebuild_index` command.")
+
+            yes_or_no = six.moves.input("Are you sure you wish to continue? [y/N] ")
+            print
+
+            if not yes_or_no.lower().startswith('y'):
+                print("No action taken.")
+                sys.exit()
+
+        call_command('search_index', action='delete', confirmed='guilty-as-charged', **options)
+        call_command('search_index', action='create', **options)

--- a/bungiesearch/management/commands/rebuild_index.py
+++ b/bungiesearch/management/commands/rebuild_index.py
@@ -1,0 +1,13 @@
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+
+from .clear_index import Command as ClearCommand
+
+
+class Command(BaseCommand):
+    help = "Rebuilds the search index by clearing the search index and then performing an update."
+    option_list = set(BaseCommand.option_list + ClearCommand.option_list)
+
+    def handle(self, **options):
+        call_command('clear_index', **options)
+        call_command('search_index', action='update', **options)

--- a/tests/core/test_bungiesearch.py
+++ b/tests/core/test_bungiesearch.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from bungiesearch import Bungiesearch
 from bungiesearch.management.commands import search_index
 from bungiesearch.utils import update_index
+from django.core.management import call_command
 from django.test import TestCase
 import pytz
 from six import iteritems
@@ -17,7 +18,7 @@ class CoreTestCase(TestCase):
         # Let's start by creating the index and mapping.
         # If we create an object before the index, the index
         # will be created automatically, and we want to test the command.
-        search_index.Command().run_from_argv(['tests', 'empty_arg', '--create'])
+        call_command('search_index', action='create')
 
         art_1 = {'title': 'Title one',
                  'description': 'Description of article 1.',
@@ -57,7 +58,7 @@ class CoreTestCase(TestCase):
         User.objects.create(**user_2)
         NoUpdatedField.objects.create(title='My title', description='This is a short description.')
 
-        search_index.Command().run_from_argv(['tests', 'empty_arg', '--update'])
+        call_command('rebuild_index', interactive=False)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Added some simple commands that are just aliases for combinations of previously existing management commands that would be commonly used in projects using Bungiesearch.

Added the logic to setup in the test to ensure that it's working properly. I've also tested this in an external application, with positive results.