### PR TITLE
Use contribute_to_class in Bungiesearch Manager

### DIFF
--- a/bungiesearch/managers.py
+++ b/bungiesearch/managers.py
@@ -25,8 +25,12 @@ class BungiesearchManager(Manager):
         from bungiesearch import Bungiesearch
         return Bungiesearch(raw_results=True).index(index).doc_type(doc_type)
 
-    def __init__(self, **kwargs):
-        super(BungiesearchManager, self).__init__(**kwargs)
+    def contribute_to_class(self, cls, name):
+        '''
+        Sets up the signal processor. Since self.model is not available
+        in the constructor, we perform this operation here.
+        '''
+        super(BungiesearchManager, self).contribute_to_class(cls, name)
 
         from . import Bungiesearch
         from .signals import get_signal_processor


### PR DESCRIPTION
Instead of using the `__init__` constructor in `managers.py`, we should be using `contribute_to_class`. As I mentioned in a previous issue, if you use `__init__`, self.model will be Python `None`. As a result, non search related models will get hooked up to the signal processor, which could result in a series of errors if you have logic specific to search models inside your signal processor.

This is all I have for you... at least until I get back from vacation in a couple of weeks :)