### PR TITLE
Bound the version of elasticsearch required

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ with open(join(dirname(__file__), 'README.rst')) as f:
 install_requires = [
     'django>=1.6',
     'elasticsearch-dsl>=0.0.4',
+    'elasticsearch>=1.0.0,<=2.1.0'
     'python-dateutil',
     'six',
 ]


### PR DESCRIPTION
Since we depend on elasticsearch-py directly, let's specify in the dependencies using the known supported version and upgrade it explicitly to avoid what happened when they upgraded to 1.8.

This is using 2.1.0 since it's the latest known version to work and we can upgrade it when we test the library with that version of elasticsearch-py

```bulk_index``` backwards compatibility was removed in 1.8 (a non major version on accident here)
https://github.com/elastic/elasticsearch-py/commit/5d4640d4c2cfd52aa92121fe41bbb383945cf6d3#diff-40bff9d086abf2457154901fada0d9acL230