### PR TITLE
Wait for create API call to finish

### DIFF
--- a/bungiesearch/management/commands/search_index.py
+++ b/bungiesearch/management/commands/search_index.py
@@ -136,6 +136,7 @@ class Command(BaseCommand):
 
                 logging.info('Creating index {} with {} doctypes.'.format(index, len(mapping)))
                 es.indices.create(index=index, body={'mappings': mapping, 'settings': {'analysis': analysis}})
+                es.cluster.health(index=index, wait_for_status='yellow')
 
         elif options['action'] == 'update-mapping':
             if options['index']:


### PR DESCRIPTION
The elasticsearch API call to create an index is actually asynchronous causing all sorts of flakey errors. You can use rebuild_index, and then if you try to immediately perform any requests shortly after they will fail with a 503 error.

This issue is documented here, https://github.com/elastic/elasticsearch-php/issues/303

I thought pretty hard and I'm not sure if this should be fixed in elasticsearch-dsl or elasticsaerch-py. I decided at minimum it should be fixed here, because this is an end user library and the decision to make it asynchronous seems to be a design choice.