### PR TITLE
rebuild index should also rebuild the model mappings

### DIFF
--- a/bungiesearch/management/commands/rebuild_index.py
+++ b/bungiesearch/management/commands/rebuild_index.py
@@ -10,4 +10,5 @@ class Command(BaseCommand):
 
     def handle(self, **options):
         call_command('clear_index', **options)
+        call_command('search_index', action='update-mapping', **options)
         call_command('search_index', action='update', **options)


### PR DESCRIPTION
I think this will be necessary to put back the model mappings after clearing the index

if you agree with this, please release a new build afterwards so that the rebuild_index command works correctly