### PR TITLE
Promoted requirements to dev requirments and not just for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - 2.7
 install: 
   - pip install .
-  - pip install -r tests/requirements.txt
+  - pip install -r requirements.txt
   - pip install coveralls
 services:
   - elasticsearch

--- a/README.rst
+++ b/README.rst
@@ -784,7 +784,7 @@ Testing
 
 All Bungiesearch tests are in ``tests/core/test_bungiesearch.py``. You
 can run the tests by creating a Python virtual environment, installing
-the requirements from ``tests/requirements.txt``, installing the package
+the requirements from ``requirements.txt``, installing the package
 (``pip install .``) and running ``python tests/manage.py test``. Make
 sure to update ``tests/settings.py`` to use your own elasticsearch URLs,
 or update the ELASTIC\_SEARCH\_URL environment variable.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+Django>=1.6
+elasticsearch-dsl>=0.0.4
+elasticsearch>=1.0.0,<=2.1.0
+python-dateutil
+six
+
+bungiesearch
+coveralls
+pytz

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e
+
+if [ $(whoami) == "root" ] && [ "$1" != "--force" ]; then
+  echo "It's not recommended to run setup with root"
+  echo 'run with --force to ignore'
+  exit 1
+fi
+
+if [ -z "$VIRTUAL_ENV" ] && [ "$1" != "--force" ]; then
+  echo "$0 should be run inside a python virtualenv"
+  echo 'run with --force to ignore'
+  exit 1
+fi
+
+echo 'Installing Python dependencies'
+pip install pip setuptools --upgrade
+pip install -r requirements.txt

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,0 @@
-Django>=1.6
-bungiesearch
-elasticsearch-dsl>=0.0.4
-pytz
-six


### PR DESCRIPTION
The requirements file was in testing before, but we need them in the front so that developers can install them for all development purposes (running tests, building a release, etc).

I also added a new setup script to help people get started more easily that will help them avoid common pitfalls like not installing in a virtual environment. Now all you need to do is run ```./setup.sh```