### PR TITLE
Wait for cluster to reach green status after creation

### DIFF
--- a/bungiesearch/management/commands/search_index.py
+++ b/bungiesearch/management/commands/search_index.py
@@ -136,7 +136,8 @@ class Command(BaseCommand):
 
                 logging.info('Creating index {} with {} doctypes.'.format(index, len(mapping)))
                 es.indices.create(index=index, body={'mappings': mapping, 'settings': {'analysis': analysis}})
-                es.cluster.health(index=index, wait_for_status='yellow')
+
+            es.cluster.health(index=','.join(indices), wait_for_status='green', timeout=30)
 
         elif options['action'] == 'update-mapping':
             if options['index']:

--- a/tests/core/test_bungiesearch.py
+++ b/tests/core/test_bungiesearch.py
@@ -60,6 +60,12 @@ class CoreTestCase(TestCase):
 
         call_command('rebuild_index', interactive=False, confirmed='guilty-as-charged')
 
+    def test_count_after_clear(self):
+        # can flake because elasticsearch create API is asynchronous
+        self.assertEqual(Article.objects.search_index('bungiesearch_demo').count(), 2)
+        call_command('rebuild_index', interactive=False, confirmed='guilty-as-charged')
+        self.assertEqual(Article.objects.search_index('bungiesearch_demo').count(), 2)
+
     @classmethod
     def tearDownClass(cls):
         call_command('search_index', action='delete', confirmed='guilty-as-charged')


### PR DESCRIPTION
I realized my other PR was great for fixing some of the flakes we encountered, but really we need to wait for the green status to avoid all the failures that can happen on production elasticsearch providers. Yellow status does not wait for all shards to finish replication, but green does!

This new solution will create all indices asynchronously and then wait on them all synchronously for a large perf boost. You will only see this error if you're using a properly configured cluster production cluster.